### PR TITLE
Allowed the passing of a map function to apply to each property

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,28 @@
 var objectPath = require('object-path');
 var sortBy;
 var sort;
+var filter;
+
+/**
+ * Filters args based on their type
+ * @param  {String} type Type of property to filter by
+ * @return {Function}
+ */
+filter = function(type) {
+    return function(arg) {
+        return typeof arg === type;
+    };
+};
 
 /**
  * Return a comparator function
  * @param  {String} property The key to sort by
+ * @param  {Function} map Function to apply to each property
  * @return {Function}        Returns the comparator function
  */
-sort = function sort(property) {
+sort = function sort(property, map) {
     var sortOrder = 1;
-    var fn;
+    var apply = map || function(_, value) { return value };
 
     if (property[0] === "-") {
         sortOrder = -1;
@@ -18,9 +31,11 @@ sort = function sort(property) {
 
     return function fn(a,b) {
         var result;
-        if (objectPath.get(a, property) < objectPath.get(b, property)) result = -1;
-        if (objectPath.get(a, property) > objectPath.get(b, property)) result = 1;
-        if (objectPath.get(a, property) === objectPath.get(b, property)) result = 0;
+        var am = apply(property, objectPath.get(a, property));
+        var bm = apply(property, objectPath.get(b, property));
+        if (am < bm) result = -1;
+        if (am > bm) result = 1;
+        if (am === bm) result = 0;
         return result * sortOrder;
     }
 };
@@ -30,8 +45,11 @@ sort = function sort(property) {
  * @return {Function} Returns the comparator function
  */
 sortBy = function sortBy() {
-    var properties = arguments;
-    var fn;
+
+    var args = Array.prototype.slice.call(arguments);
+
+    var properties = args.filter(filter('string'));
+    var map = args.filter(filter('function'))[0];
 
     return function fn(obj1, obj2) {
         var numberOfProperties = properties.length,
@@ -42,7 +60,7 @@ sortBy = function sortBy() {
          * as long as we have extra properties to compare
          */
         while(result === 0 && i < numberOfProperties) {
-            result = sort(properties[i])(obj1, obj2);
+            result = sort(properties[i], map)(obj1, obj2);
             i++;
         }
         return result;

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 var objectPath = require('object-path');
 var sortBy;
 var sort;
-var filter;
+var type;
 
 /**
  * Filters args based on their type
  * @param  {String} type Type of property to filter by
  * @return {Function}
  */
-filter = function(type) {
+type = function(type) {
     return function(arg) {
         return typeof arg === type;
     };
@@ -47,9 +47,8 @@ sort = function sort(property, map) {
 sortBy = function sortBy() {
 
     var args = Array.prototype.slice.call(arguments);
-
-    var properties = args.filter(filter('string'));
-    var map = args.filter(filter('function'))[0];
+    var properties = args.filter(type('string'));
+    var map = args.filter(type('function'))[0];
 
     return function fn(obj1, obj2) {
         var numberOfProperties = properties.length,

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,34 @@ describe('Sort(prop)', function () {
         assert(array[3].x === 4);
         assert(array[3].y === 1);
     });
+    it('sorts an array case-insensitively by applying a function', function() {
+
+        var array = [
+            { name: 'Hummingbird' },
+            { name: 'swallow' },
+            { name: 'Finch' },
+            { name: 'Sparrow' },
+            { name: 'cuckoos' }
+        ];
+
+       array.sort(sortBy('name'));
+       assert(array[0].name === 'Finch');
+       assert(array[1].name === 'Hummingbird');
+       assert(array[2].name === 'Sparrow');
+       assert(array[3].name === 'cuckoos');
+       assert(array[4].name === 'swallow');
+
+       array.sort(sortBy('name', function(key, value) {
+            return key === 'name' ? value.toLowerCase() : value;
+       }));
+
+       assert(array[0].name === 'cuckoos');
+       assert(array[1].name === 'Finch');
+       assert(array[2].name === 'Hummingbird');
+       assert(array[3].name === 'Sparrow');
+       assert(array[4].name === 'swallow');
+
+    });
 });
 
 describe('Sort(prop, prop)', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -43,9 +43,9 @@ describe('Sort(prop)', function () {
        assert(array[3].name === 'cuckoos');
        assert(array[4].name === 'swallow');
 
-       array.sort(sortBy('name', function(key, value) {
-            return key === 'name' ? value.toLowerCase() : value;
-       }));
+array.sort(sortBy('name', function(key, value) {
+    return key === 'name' ? value.toLowerCase() : value;
+}));
 
        assert(array[0].name === 'cuckoos');
        assert(array[1].name === 'Finch');

--- a/test/index.js
+++ b/test/index.js
@@ -43,9 +43,9 @@ describe('Sort(prop)', function () {
        assert(array[3].name === 'cuckoos');
        assert(array[4].name === 'swallow');
 
-array.sort(sortBy('name', function(key, value) {
-    return key === 'name' ? value.toLowerCase() : value;
-}));
+       array.sort(sortBy('name', function(key, value) {
+           return key === 'name' ? value.toLowerCase() : value;
+       }));
 
        assert(array[0].name === 'cuckoos');
        assert(array[1].name === 'Finch');


### PR DESCRIPTION
I've allowed the passing of **one** `function` to the `sortBy` function to allow for manipulating the comparison values &mdash; it passes the `key` and the `value`. If it's not set then the function is a simple `identity` which yields the value as-is.

I thought this would be a better approach instead of introducing a prefix to lowercase properties, because using prefixes can become esoteric &ndash; the current `-` to reverse sorting makes sense, however.

We would use it like so:

```javascript
array.sort(sortBy('name', 'age', 'location', function(key, value) {
    return key === 'name' ? value.toLowerCase() : value;
}));
```

As you're using the `arguments` instead of passing an array, I've had to do something a little quirky to filter the `arguments` by `string` and then `function`. I think ideally the `sortBy` would accept `array, function` but that would have been a breaking change.

I've used `filter` instead of `find` for the `typeof x === 'function'` check as that has greater support than `[].find`.