### PR TITLE
fix: support date objects and other non-primitive values

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,12 +30,11 @@ sort = function sort(property, map) {
     }
 
     return function fn(a,b) {
-        var result;
         var am = apply(property, objectPath.get(a, property));
         var bm = apply(property, objectPath.get(b, property));
+        var result = 0;
         if (am < bm) result = -1;
         if (am > bm) result = 1;
-        if (am === bm) result = 0;
         return result * sortOrder;
     }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,27 @@ describe('Sort(prop, prop)', function () {
         assert(array[3].x === 2);
         assert(array[3].y === 3);
     });
+
+    it('supports Date objects', function() {
+        var date1 = new Date('2018-01-01T00:00:00Z')
+        var date2 = new Date('2018-01-02T00:00:00Z')
+        var date3 = new Date('2018-01-03T00:00:00Z')
+
+        var array = [
+            { name: 'Hummingbird', date: new Date(date1) },
+            { name: 'swallow', date: new Date(date2) },
+            { name: 'Finch', date: new Date(date1) },
+            { name: 'Sparrow', date: new Date(date2) },
+            { name: 'cuckoos', date: new Date(date3) }
+        ];
+
+       array.sort(sortBy('date', 'name'));
+       assert(array[0].name === 'Finch');
+       assert(array[1].name === 'Hummingbird');
+       assert(array[2].name === 'Sparrow');
+       assert(array[3].name === 'swallow');
+       assert(array[4].name === 'cuckoos');
+    });
 });
 
 describe('Sort(-prop)', function () {


### PR DESCRIPTION
When sorting by multiple props that include `Date` objects, you'll end up with incorrect sorting in cases where the underlying date _value_ is the same. The use of `===` (after checking `<` and `>`) will always return `false` for `Date` objects, since `===` compares identity for objects. The result of the final `result * sortOrder` becomes `NaN`, which then causes iteration to stop (since the check is looking for `=== 0`).

Just to be clear, this edge-case does **not** occur when you are only sorting by 1 property, it only comes up for properties following the aforementioned `Date` objects.

The change here assumes that the returned value will be `0`, and will only change to `-1` for `<` and `1` for `>`. This change is backwards-compatible, and will allow non-primitive values (such as `Date`) to be handled more gracefully.

This change also includes a test case that was failing before my change, but now passes.